### PR TITLE
Add support for boolean values. Useful for checkboxes.

### DIFF
--- a/features/data_magic.feature
+++ b/features/data_magic.feature
@@ -38,3 +38,6 @@ Feature: Functionality of the data_magic gem
     And the value for "sentences" should exist
     And the value for "paragraphs" should exist
 
+  Scenario: Boolean values
+    Then the value for "bool_true" should be true
+    And the value for "bool_false" should be false

--- a/features/step_definitions/data_magic_steps.rb
+++ b/features/step_definitions/data_magic_steps.rb
@@ -16,6 +16,10 @@ Then /^the value for "(.+)" should be "(.+)"$/ do |key, value|
   @data[key].should == value
 end
 
+Then /^the value for "(.+)" should be (true|false)$/ do |key, value|
+  @data[key].should == eval(value)
+end
+
 Then /^the value for "(.+)" should be (\d+) word|words long$/ do |key, length|
   @data[key].split(' ').size.should == length.to_i
 end

--- a/features/yaml/example.yml
+++ b/features/yaml/example.yml
@@ -19,3 +19,5 @@ dm:
   sentence: ~sentence
   sentences: ~sentences
   paragraphs: ~paragraphs
+  bool_true: true
+  bool_false: false

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -19,6 +19,7 @@ module DataMagic
   def prep_data(data)
     data.each do |key, value|
       unless value.nil?
+        next unless value.respond_to? '[]'
         data[key] = eval(value[1..-1]) if value[0] == "~"
       end
     end

--- a/spec/lib/translation_spec.rb
+++ b/spec/lib/translation_spec.rb
@@ -202,5 +202,17 @@ describe "DataMagic translations" do
         example.data_for('key')['field'].split('\n\n').size.should == 10
       end
     end
+
+    context "translating boolean values" do
+      it "should resolve true" do
+        set_field_value true
+        example.data_for('key').should have_field_value true
+      end
+
+      it "should resolve false" do
+        set_field_value false
+        example.data_for('key').should have_field_value false
+      end
+    end
   end
 end


### PR DESCRIPTION
I was moving some existing default data to data_magic, but boolean values wouldn't work because the fuubar feature assumed the value responded to [] during the check for a leading ~.
