### PR TITLE
Fix numeric values and undefined keys

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -20,6 +20,7 @@ module DataMagic
   def data_for(key, additional={})
     DataMagic.load('default.yml') unless DataMagic.yml
     data = DataMagic.yml[key.to_s]
+    raise ArgumentError, "Undefined key #{key}" unless data
     prep_data data.merge(additional).clone
   end
 
@@ -28,7 +29,7 @@ module DataMagic
   def prep_data(data)
     data.each do |key, value|
       unless value.nil?
-        next unless value.respond_to? '[]'
+        next if !value.respond_to?('[]') || value.is_a?(Numeric)
         data[key] = translate(value[1..-1]) if value[0,1] == "~"
       end
     end

--- a/spec/lib/translation_spec.rb
+++ b/spec/lib/translation_spec.rb
@@ -250,6 +250,19 @@ describe "DataMagic translations" do
       end
     end
 
+    context "with numeric values" do
+      it "doesn't translate values" do
+        set_field_value(1)
+        example.data_for("key").should have_field_value 1
+      end
+    end
+
+    context "with values not in the yaml" do
+      it "throws a ArgumentError" do
+        expect { example.data_for("inexistant_key") }.to raise_error ArgumentError
+      end
+    end
+
     context "providing date values" do
       it "should provide today's date" do
         set_field_value '~today'


### PR DESCRIPTION
Using numeric values crashes
Using keys not in the YAML throws `undefined method 'merge' for nil:NilClass>`
Also, numeric values respond to `[](value)` but not `[](start, finish)`
