### PR TITLE
Improve how additional data is merged when loading.

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -37,7 +37,7 @@ module DataMagic
     end
     data = DataMagic.yml[record]
     raise ArgumentError, "Undefined key #{key}" unless data
-    prep_data data.merge(additional).clone
+    additional.key?(record) ? prep_data(data.merge(additional[record]).clone) : prep_data(data.merge(additional).clone)
   end
 
   private

--- a/spec/lib/data_magic_spec.rb
+++ b/spec/lib/data_magic_spec.rb
@@ -48,6 +48,17 @@ describe DataMagic do
       expect(data.keys.sort).to eq(['job','name'])
       ENV['DATA_MAGIC_FILE'] = nil
     end
+
+    it 'should merge additional data to the same key if not present in addtional' do
+      DataMagic.yml_directory = 'config/data'
+      data = UserPage.new.data_for 'user/valid', {'job' => 'Overlord'}
+      expect(data['job']).to eq('Overlord')
+    end
+    it 'should merge additional data to resulting hash if present in additional data' do
+      DataMagic.yml_directory = 'config/data'
+      data = UserPage.new.data_for 'user/valid', { 'valid' => {'job' => 'Overlord'} }
+      expect(data['job']).to eq('Overlord')
+    end
   end
 
   context "namespaced keys" do


### PR DESCRIPTION
Additional data can come in two forms:
- A bare hash, which will be merged into the hash we get from the yml file. i.e. data_for 'user_info', {username: 'fred', state: 'oh'} (Original behavior)
- A hash of hashes, that has keys that line up with your request. i.e. data_for 'user_info', {user_info: username: 'fred', state: 'oh'}}
