### PR TITLE
Add support to loading fixture data via tags.  Cucumber only ATM.

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -40,6 +40,17 @@ module DataMagic
     prep_data data.merge(additional).clone
   end
 
+  # Given a scenario, load any fixture it needs.
+  # Fixture tags should be in the form of @fixture_FIXTUREFILE
+  def self.load_for_cuke_scenario(scenario, fixture_folder = DataMagic.yml_directory)
+    orig_yml_directory = DataMagic.yml_directory
+    DataMagic.yml_directory = fixture_folder
+    fixture_files = fixture_files_on(scenario)
+    STDERR.puts "Found #{fixture_files.count} fixtures on scenario.  Using #{fixture_files.last}." if fixture_files.count > 1
+    DataMagic.load "#{fixture_files.last}.yml" if fixture_files.count > 0
+    DataMagic.yml_directory = orig_yml_directory
+  end
+
   private
 
   def the_file
@@ -66,6 +77,24 @@ module DataMagic
 
   def translation
     @translation ||= Translation.new parent
+  end
+
+  # Load a fixture and merge it with an existing hash
+  def self.load_fixture_and_merge_with(fixture_name, base_hash, fixture_folder = DEFAULT_FIXTURE_FOLDER)
+    new_hash = load_fixture(fixture_name, fixture_folder)
+    base_hash.deep_merge new_hash
+  end
+
+  def self.fixture_tags_on(scenario)
+    # tags for cuke 2, source_tags for cuke 1
+    tags = scenario.send(scenario.respond_to?(:tags) ? :tags : :source_tags)
+    tags.map(&:name).select { |t| t =~ /@fixture_/ }
+  end
+
+  def self.fixture_files_on(scenario)
+    # tags for cuke 2, source_tags for cuke 1
+    tags = scenario.send(scenario.respond_to?(:tags) ? :tags : :source_tags)
+    tags.map(&:name).select { |t| t =~ /@fixture_/ }.map { |t| t.gsub('@fixture_', '').to_sym }
   end
 
   class << self

--- a/spec/lib/data_magic_spec.rb
+++ b/spec/lib/data_magic_spec.rb
@@ -4,6 +4,21 @@ class UserPage
   include DataMagic
 end
 
+class MockScenario
+  attr_accessor :tags
+  def initialize(tags)
+    @tags = tags
+  end
+end
+
+class MockTag
+  attr_reader :name, :line
+  def initialize(name, line)
+    @name = name
+    @line = line
+  end
+end
+
 describe DataMagic do
   context "when configuring the yml directory" do
     before(:each) do
@@ -55,6 +70,29 @@ describe DataMagic do
       DataMagic.yml_directory = 'config/data'
       data = UserPage.new.data_for "user/valid"
       expect(data.keys.sort).to eq(['job','name'])
+    end
+  end
+
+  context "loading fixtures for cucumber scenarios" do
+    it "loads the fixture for a scenario" do
+      DataMagic.yml_directory = 'config/data'
+      scenario = MockScenario.new([MockTag.new('@tag', 1), MockTag.new('@fixture_user', 1)])
+      expect(DataMagic).to receive(:load).with('user.yml')
+      DataMagic.load_for_cuke_scenario scenario
+    end
+
+    it "uses the last fixture listed for a scenario if multiple exist" do
+      scenario = MockScenario.new([MockTag.new('@fixture_default', 1), MockTag.new('@fixture_user', 1)])
+      expect(DataMagic).to receive(:load).with('user.yml')
+      DataMagic.load_for_cuke_scenario scenario
+    end
+
+    it "allows you to force loading from a different folder without stepping on the global folder" do
+      DataMagic.yml_directory = 'features'
+      scenario = MockScenario.new([MockTag.new('@tag', 1), MockTag.new('@fixture_user', 1)])
+      expect(DataMagic).to receive(:load).with('user.yml')
+      DataMagic.load_for_cuke_scenario scenario, 'config/data'
+      expect(DataMagic.yml_directory).to eq('features')
     end
   end
 end


### PR DESCRIPTION
This allows you to place a tag on your scenarios in the format of @fixture_FILENAME and have DataMagic load them in a hook like so:

Before do |scenario|
  DataMagic.load_for_cuke_scenario(scenario)
end
