### PR TITLE
Avoid adding the TestSubject class to the shared namespace.

### DIFF
--- a/spec/lib/translation_spec.rb
+++ b/spec/lib/translation_spec.rb
@@ -1,17 +1,12 @@
 require 'spec_helper'
-
-class TestSubject
-  include DataMagic
-end
-
 describe "DataMagic translations" do
   context "when delivering data" do
-    let(:example) { TestSubject.new }
+    let(:example) { (Class.new { include DataMagic }).new }
 
     def set_field_value(value)
       expect(DataMagic).to receive(:yml).twice.and_return({'key' => {'field' => value}})
     end
-    
+
     it "should deliver the hash from the yaml" do
       set_field_value 'value'
       expect(example.data_for('key')).to have_field_value 'value'
@@ -170,7 +165,7 @@ describe "DataMagic translations" do
         expect(example.data_for('key')).to have_field_value 'very_cheezy'
       end
     end
-    
+
     context "translating phone numbers" do
       it "shold add a phone number" do
         expect(Faker::PhoneNumber).to receive(:phone_number).and_return('555-555-5555')


### PR DESCRIPTION
I've had trouble in the past because I've created a `TestSubject` in multiple specs and they have interacted with each other (at the time much to my surprise).

So now, I prefer to create an anonymous class into which I can include the module that I want to test.