### PR TITLE
Use named parameters and update job titles

### DIFF
--- a/features/data_magic.feature
+++ b/features/data_magic.feature
@@ -14,7 +14,7 @@ Feature: Functionality of the data_magic gem
     And the value for "last_name" should be 1 word long
     And the value for "name_prefix" should be 1 word long
     And the value for "name_suffix" should be 1 word long
-    And the value for "title" should have a minimum of 3 words
+    And the value for "title" should have a minimum of 2 words
 
   Scenario: Getting addresses from the yaml
     Then the value for "street" should have a minimum of 2 words

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,6 +3,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../../', 'lib'))
 require 'rspec/expectations'
 require 'data_magic'
 
+DataMagic.locale = 'en-US'
+
 Before do
   DataMagic.yml_directory = nil
   DataMagic.yml = nil

--- a/lib/data_magic/standard_translation.rb
+++ b/lib/data_magic/standard_translation.rb
@@ -47,7 +47,7 @@ module DataMagic
     # return a random title
     #
     def title
-      Faker::Name.title
+      Faker::Job.title
     end
     alias_method :dm_title, :title
 
@@ -55,7 +55,7 @@ module DataMagic
     # return a random street address
     #
     def street_address(include_secondary=false)
-      Faker::Address.street_address(include_secondary)
+      Faker::Address.street_address(include_secondary: include_secondary)
     end
     alias_method :dm_street_address, :street_address
 
@@ -144,7 +144,7 @@ module DataMagic
     # return random words - default is 3 words
     #
     def words(number = 3)
-      Faker::Lorem.words(number).join(' ')
+      Faker::Lorem.words(number: number).join(' ')
     end
     alias_method :dm_words, :words
 
@@ -152,7 +152,7 @@ module DataMagic
     # return a random sentence - default minimum word count is 4
     #
     def sentence(min_word_count = 4)
-      Faker::Lorem.sentence(min_word_count)
+      Faker::Lorem.sentence(word_count: min_word_count)
     end
     alias_method :dm_sentence, :sentence
 
@@ -160,7 +160,7 @@ module DataMagic
     # return random sentences - default is 3 sentences
     #
     def sentences(sentence_count = 3)
-      Faker::Lorem.sentences(sentence_count).join(' ')
+      Faker::Lorem.sentences(number: sentence_count).join(' ')
     end
     alias_method :dm_sentences, :sentences
 
@@ -168,7 +168,7 @@ module DataMagic
     # return random paragraphs - default is 3 paragraphs
     #
     def paragraphs(paragraph_count = 3)
-      Faker::Lorem.paragraphs(paragraph_count).join('\n\n')
+      Faker::Lorem.paragraphs(number: paragraph_count).join('\n\n')
     end
     alias_method :dm_paragraphs, :paragraphs
 
@@ -176,7 +176,7 @@ module DataMagic
     # return random characters - default is 255 characters
     #
     def characters(character_count = 255)
-      Faker::Lorem.characters(character_count)
+      Faker::Lorem.characters(number: character_count)
     end
     alias_method :dm_characters, :characters
 
@@ -184,7 +184,7 @@ module DataMagic
     # return a random email address
     #
     def email_address(name=nil)
-      Faker::Internet.email(name)
+      Faker::Internet.email(name: name)
     end
     alias_method :dm_email_address, :email_address
 


### PR DESCRIPTION
Due to the changes made in https://github.com/faker-ruby/faker/pull/1698, `Faker` will keep dumping out deprecation warnings. This PR fixes the positional usages and switches to named parameters. 

Additionally, it has been updated to reflect changes made to `Faker::Name.title`, which has been removed in favor of `Faker::Job.title`.

I needed to set the locale to `en-US` in order to get the tests to pass, but I can remove that commit if you don't want it.